### PR TITLE
Add log channel functionality for spam detection

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -29,6 +29,10 @@ func main() { //nolint:gocyclo,gocognit
 	newUserThreshold := flag.Int("new-user-threshold", 1, "Threshold for classifying user as new")
 	var whitelistChannels intSliceFlag
 	flag.Var(&whitelistChannels, "whitelist-channels", "Comma-separated list of whitelisted channel IDs")
+
+	var logChannels logChannelsFlag
+	flag.Var(&logChannels, "log-channels", "Comma-separated list of working chat ID and log channel ID pairs in the format 'workingChatID1:logChannelID1,workingChatID2:logChannelID2'")
+
 	flag.Parse()
 
 	var logLevelValue slog.Level
@@ -139,6 +143,7 @@ func main() { //nolint:gocyclo,gocognit
 		Threshold:         *threshold,
 		NewUserThreshold:  *newUserThreshold,
 		WhitelistChannels: whitelistChannels,
+		LogChannels:       logChannels,
 	})
 
 	if err != nil {
@@ -186,5 +191,40 @@ func (i *intSliceFlag) Set(value string) error {
 		*i = append(*i, intValue)
 	}
 
+	return nil
+}
+
+// logChannelsFlag is a custom flag type for a map of working chat IDs to log channel IDs
+type logChannelsFlag map[int64]int64
+
+func (l *logChannelsFlag) String() string {
+	var pairs []string
+	for workingChatID, logChannelID := range *l {
+		pairs = append(pairs, fmt.Sprintf("%d:%d", workingChatID, logChannelID))
+	}
+	return strings.Join(pairs, ",")
+}
+
+func (l *logChannelsFlag) Set(value string) error {
+	pairs := strings.Split(value, ",")
+	*l = make(map[int64]int64)
+	for _, pair := range pairs {
+		parts := strings.Split(strings.TrimSpace(pair), ":")
+		if len(parts) != 2 {
+			return fmt.Errorf("invalid format for log channel pair, expected 'workingChatID:logChannelID'")
+		}
+
+		workingChatID, err := strconv.ParseInt(parts[0], 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid working chat ID: %v", err)
+		}
+
+		logChannelID, err := strconv.ParseInt(parts[1], 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid log channel ID: %v", err)
+		}
+
+		(*l)[workingChatID] = logChannelID
+	}
 	return nil
 }

--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -198,7 +198,7 @@ func (i *intSliceFlag) Set(value string) error {
 type logChannelsFlag map[int64]int64
 
 func (l *logChannelsFlag) String() string {
-	var pairs []string
+	pairs := make([]string, len(*l))
 	for workingChatID, logChannelID := range *l {
 		pairs = append(pairs, fmt.Sprintf("%d:%d", workingChatID, logChannelID))
 	}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,10 +21,11 @@ services:
       "-prompt=${PROMPT:-/root/prompt.txt}",
       "-model=${MODEL:-claude-3-5-sonnet-20240620}",
       "-provider=${PROVIDER:-anthropic}",
-      "-spam-threshold=${SPAM_THRESHOLD:-0.6}",
+      "-spam-threshold=${SPAM_THRESHOLD}", #0.5
       "-new-user-threshold=${NEW_USER_THRESHOLD:-1}",
-      "-whitelist-channels=${WHITELIST_CHANNELS:-}", # comma separated, for example: "-1001098030726" (CTO daily chat)
-      "-log-level=${LOG_LEVEL:-info}"
+      "-whitelist-channels=${WHITELIST_CHANNELS}", # comma separated, for example: "-1001098030726" (CTO daily chat)
+      "-log-level=${LOG_LEVEL:-info}",
+      "-log-channels=${LOG_CHANNELS}" # comma-separated list of working chat ID and log channel ID pairs, for example: "-1001098030726:-1001089898989,-1001098030727:-1001089898990" (first pair: CTO daily chat and its log channel, second pair: another chat and its log channel)
     ]
 
   redis:


### PR DESCRIPTION
This change introduces a new feature to forward detected spam messages to designated log channels. It allows admins to configure pairs of working chat IDs and corresponding log channel IDs where spam alerts will be sent.

The implementation includes:
- A new custom flag type for log channel configuration
- Forwarding of spam messages to the appropriate log channel
- Sending additional spam detection details to the log channel
- Updating the Docker configuration to support the new feature

This enhancement improves spam monitoring capabilities and provides a centralized way for admins to review and manage spam across multiple channels.

Closes #123

Add log channel feature for spam monitoring

Implement a system to forward detected spam messages to designated log channels. This enhances spam monitoring capabilities by providing admins with a centralized view of spam across multiple channels.

Key changes:
- Introduce custom flag for log channel configuration
- Forward spam messages to configured log channels
- Send detailed spam detection information to log channels
- Update Docker configuration to support the new feature

This improvement allows for better spam management and oversight in multi-channel environments.

Closes #123