### PR TITLE
Implement spam message caching for faster detection

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -1,0 +1,67 @@
+package cache
+
+import (
+	"container/list"
+	"sync"
+)
+
+type LRUCache struct {
+	capacity int
+	cache    map[string]*list.Element
+	list     *list.List
+	mutex    sync.RWMutex
+}
+
+type entry struct {
+	key   string
+	value interface{}
+}
+
+func NewLRUCache(capacity int) *LRUCache {
+	return &LRUCache{
+		capacity: capacity,
+		cache:    make(map[string]*list.Element),
+		list:     list.New(),
+	}
+}
+
+func (c *LRUCache) Get(key string) (interface{}, bool) {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+
+	if elem, ok := c.cache[key]; ok {
+		c.list.MoveToFront(elem)
+		return elem.Value.(*entry).value, true
+	}
+	return nil, false
+}
+
+func (c *LRUCache) Put(key string, value interface{}) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	if elem, ok := c.cache[key]; ok {
+		c.list.MoveToFront(elem)
+		elem.Value.(*entry).value = value
+		return
+	}
+
+	if c.list.Len() >= c.capacity {
+		oldest := c.list.Back()
+		if oldest != nil {
+			c.list.Remove(oldest)
+			delete(c.cache, oldest.Value.(*entry).key)
+		}
+	}
+
+	elem := c.list.PushFront(&entry{key: key, value: value})
+	c.cache[key] = elem
+}
+
+func (c *LRUCache) Contains(key string) bool {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+
+	_, ok := c.cache[key]
+	return ok
+}


### PR DESCRIPTION
This change introduces a new LRU cache to store previously identified spam messages. By caching spam content, the bot can quickly recognize and delete repeated spam without needing to re-process through the AI provider. This optimization improves response time and reduces unnecessary API calls, enhancing overall performance and efficiency.

The cache is initialized with a capacity of 1000 entries, which can be adjusted as needed based on observed spam patterns and system resources.