### PR TITLE
Added .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+result.json


### PR DESCRIPTION
No need to pull `result.json` into docker context, especially a big one

![image](https://github.com/user-attachments/assets/aa969992-cf6f-4ac5-836a-88b4b1d0081c)
