### PR TITLE
Update Telegram Bot API and Go version, refactor bot and message hand…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,13 @@
 module github.com/ailabhub/giraffe-spam-crasher
 
-go 1.21.1
+go 1.23
+
+toolchain go1.23.2
 
 require (
+	github.com/OvyFlash/telegram-bot-api/v6 v6.0.0-20241030124621-1376e01c644a
 	github.com/avast/retry-go v2.7.0+incompatible
 	github.com/disintegration/imaging v1.6.2
-	github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1
 	github.com/google/generative-ai-go v0.17.0
 	github.com/redis/go-redis/v9 v9.6.1
 	github.com/sashabaranov/go-openai v1.27.1

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ cloud.google.com/go/compute/metadata v0.3.0/go.mod h1:zFmK7XCadkQkj6TtorcaGlCW1h
 cloud.google.com/go/longrunning v0.5.7 h1:WLbHekDbjK1fVFD3ibpFFVoyizlLRl73I7YKuAKilhU=
 cloud.google.com/go/longrunning v0.5.7/go.mod h1:8GClkudohy1Fxm3owmBGid8W0pSgodEMwEAztp38Xng=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/OvyFlash/telegram-bot-api/v6 v6.0.0-20241030124621-1376e01c644a h1:qd9GXTWjgVMBT6y6ZQYyDlClxmCu+Y3t97CjcVwoi5s=
+github.com/OvyFlash/telegram-bot-api/v6 v6.0.0-20241030124621-1376e01c644a/go.mod h1:50qGCPZYnfXyIPY2Cs8jyHFHc4aelAAygXInR3O2Owc=
 github.com/avast/retry-go v2.7.0+incompatible h1:XaGnzl7gESAideSjr+I8Hki/JBi+Yb9baHlMRPeSC84=
 github.com/avast/retry-go v2.7.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
@@ -41,8 +43,6 @@ github.com/go-logr/logr v1.4.1 h1:pKouT5E8xu9zeFC39JXRDukb6JFQPXM5p5I91188VAQ=
 github.com/go-logr/logr v1.4.1/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
-github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1 h1:wG8n/XJQ07TmjbITcGiUaOtXxdrINDz1b0J1w0SzqDc=
-github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1/go.mod h1:A2S0CWkNylc2phvKXWBBdD3K0iGnDBGbzRpISP2zBl8=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=

--- a/internal/spam/processor/spam_processor.go
+++ b/internal/spam/processor/spam_processor.go
@@ -45,8 +45,8 @@ func (s *SpamProcessor) CheckForSpam(ctx context.Context, message *structs.Messa
 		return spamScore, nil
 	}
 
-	if !message.HasText() && !message.HasImage() {
-		jsonMessage, err := json.Marshal(message)
+	if !message.HasText() && !message.HasImage() && !message.HasQuote() {
+		jsonMessage, err := json.Marshal(message.RawOriginal)
 		if err != nil {
 			slog.Error("json.Marshal", "error", err)
 		}

--- a/internal/structs/message.go
+++ b/internal/structs/message.go
@@ -4,6 +4,8 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"time"
+
+	tgbotapi "github.com/OvyFlash/telegram-bot-api/v6"
 )
 
 type Message struct {
@@ -18,10 +20,16 @@ type Message struct {
 	UserName    string
 	ReceivedAt  time.Time
 	MessageTime time.Time
+	Quote       string
+	RawOriginal *tgbotapi.Message
 }
 
 func (m *Message) HasImage() bool {
 	return m.Image != nil
+}
+
+func (m *Message) HasQuote() bool {
+	return m.Quote != ""
 }
 
 func (m *Message) HasText() bool {


### PR DESCRIPTION
…ling

- Switch from go-telegram-bot-api/v5 to OvyFlash/telegram-bot-api/v6
- Update Go version to 1.23 with toolchain specification
- Modify bot message handling to use new API's ReplyParameters and ChatConfig
- Add support for message quotes in message struct
- Update spam processor to handle new message structure