### PR TITLE
Moved check if the message is empty

### DIFF
--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -2,6 +2,7 @@ package bot
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -117,6 +118,15 @@ func (b *Bot) handleUpdate(update tgbotapi.Update, me *tgbotapi.User) {
 	message, err := b.fromTGToInternalMessage(ctx, update.Message)
 	if err != nil {
 		b.logger.Error("Error converting message", "error", err)
+		return
+	}
+
+	if message.IsEmpty() {
+		jsonMessage, err := json.Marshal(message)
+		if err != nil {
+			b.logger.Error("json.Marshal", "error", err)
+		}
+		b.logger.Warn("Message has no text or image, skipping spam check", "message", string(jsonMessage))
 		return
 	}
 

--- a/internal/spam/processor/spam_processor.go
+++ b/internal/spam/processor/spam_processor.go
@@ -45,15 +45,6 @@ func (s *SpamProcessor) CheckForSpam(ctx context.Context, message *structs.Messa
 		return spamScore, nil
 	}
 
-	if !message.HasText() && !message.HasImage() && !message.HasQuote() {
-		jsonMessage, err := json.Marshal(message.RawOriginal)
-		if err != nil {
-			slog.Error("json.Marshal", "error", err)
-		}
-		slog.Warn("Message has no text or image, skipping spam check", "message", string(jsonMessage))
-		return structs.SpamCheckResult{}, nil
-	}
-
 	err = retry.Do(
 		func() error {
 			spamScore, err = s.getSpamScoreForMessage(ctx, message)

--- a/internal/structs/message.go
+++ b/internal/structs/message.go
@@ -36,6 +36,10 @@ func (m *Message) HasText() bool {
 	return m.Text != ""
 }
 
+func (m *Message) IsEmpty() bool {
+	return !m.HasText() && !m.HasImage() && !m.HasQuote()
+}
+
 func (m *Message) ToAnthropicMessage(prompt string) (AnthropicMessage, error) {
 	content := []AnthropicContent{
 		{


### PR DESCRIPTION
It prevents things like this when new user joins chat:

![image](https://github.com/user-attachments/assets/852ce49d-cccb-47ea-9bf7-f31e1ac379ea)
